### PR TITLE
Fix Redshift dialect

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -173,7 +173,7 @@ func (rs RedshiftDialect) dbVersionQuery(db *sql.DB) (*sql.Rows, error) {
 }
 
 func (rs RedshiftDialect) deleteVersionSQL() string {
-	return fmt.Sprintf("DELETE FROM %s WHERE version_id=?;", TableName())
+	return fmt.Sprintf("DELETE FROM %s WHERE version_id=$1;", TableName())
 }
 
 ////////////////////////////


### PR DESCRIPTION
Copy fix from pressly/goose#146.  At some point (probably after we upgrade our go version) we should update our goose fork from upstream.